### PR TITLE
Relaxed restriction on t_int lower bound

### DIFF
--- a/atlast_sc/calculator.py
+++ b/atlast_sc/calculator.py
@@ -278,13 +278,12 @@ class Calculator:
         :rtype: astropy.units.Quantity
         """
 
-        # Use the internally stored integration time if t_int is not
-        #   supplied
-        t_int = t_int if t_int is not None else self.t_int
+        if t_int is not None:
+            self.t_int = t_int
 
         sensitivity = \
             self.sefd / \
-            (self.eta_s * np.sqrt(self.n_pol * self.bandwidth * t_int))
+            (self.eta_s * np.sqrt(self.n_pol * self.bandwidth * self.t_int))
 
         # Convert the output to mJy
         # TODO: we may want to make this configurable in future
@@ -313,12 +312,10 @@ class Calculator:
         :rtype: astropy.units.Quantity
         """
 
-        # Use the internally stored sensitivity if this value is not
-        #   supplied.
-        sensitivity = sensitivity if sensitivity is not None \
-            else self.sensitivity
+        if sensitivity is not None:
+            self.sensitivity = sensitivity
 
-        t_int = (self.sefd / (sensitivity * self.eta_s)) ** 2 \
+        t_int = (self.sefd / (self.sensitivity * self.eta_s)) ** 2 \
             / (self.n_pol * self.bandwidth)
         t_int = t_int.to(u.s)
 

--- a/atlast_sc/data.py
+++ b/atlast_sc/data.py
@@ -22,7 +22,8 @@ class DataType:
 integration_time = DataType(
     default_value=100,
     default_unit=str(u.s),
-    lower_value=1,
+    lower_value=0,
+    lower_value_is_floor=True,
     upper_value=float('inf'),
     upper_value_is_ceil=True,
     units=[str(u.s), str(u.min), str(u.h)]

--- a/demo/run.py
+++ b/demo/run.py
@@ -29,15 +29,16 @@ print("-----------")
 # calculator.sensitivity = float('inf')*u.Jy
 # calculator.n_pol = 1
 # print('using params', calculator.calculation_parameters_as_dict)
-calculated_sensitivity = \
-    calculator.calculate_sensitivity(calculator.t_int)
-print("Sensitivity: {:0.2f} for an integration time of {:0.2f} "
-      .format(calculated_sensitivity, calculator.t_int))
-calculator.sensitivity = calculated_sensitivity
-
+# calculated_sensitivity = \
+#     calculator.calculate_sensitivity()
+# print("Sensitivity: {:0.2f} for an integration time of {:0.2f} "
+#       .format(calculated_sensitivity, calculator.t_int))
+# calculator.sensitivity = calculated_sensitivity
+calculator.bandwidth = 150*u.MHz
+sens = 10*u.mJy
 # # Calculate the integration time for a given sensitivity
 calculated_t_int = \
-    calculator.calculate_t_integration()
+    calculator.calculate_t_integration(sens)
 print("Integration time: {:0.2f} to obtain a sensitivity of {:0.2f}"
       .format(calculated_t_int, calculator.sensitivity))
 # calculator.t_int = calculated_t_int

--- a/docs/source/calculator_info/user_input.rst
+++ b/docs/source/calculator_info/user_input.rst
@@ -15,7 +15,7 @@ User input
       - t_int
       - 100
       - s
-      - > 1s
+      - > 0
       - s, min, h
     * - Sensitivity
       - sensitivity

--- a/docs/source/user_guide/using_the_calculator.rst
+++ b/docs/source/user_guide/using_the_calculator.rst
@@ -36,7 +36,7 @@ set the bandwidth after initializing the calculator:
 
 .. code-block:: python
 
-    calculator.bandwidth = 10*u.GHz
+    calculator.bandwidth = 150*u.MHz
 
 .. note::
 
@@ -73,11 +73,16 @@ You can also specify a sensitivity to perform the integration time calculation:
     sens = 10*u.mJy
     calculated_t_int = calculator.calculate_t_integration(sens)
 
+.. note::
+
+    If an integration time is passed to ``calculate_sensitivity``, this value
+    is stored in the Calculator object. Similarly, a sensitivity passed to
+    ``calculate_t_integration`` is stored by the Calculator object.
 
 .. note::
 
-    When the sensitivity or integration time calculations are performed,
-    the corresponding parameters stored in the Calculator object are updated by default.
+    When the sensitivity or integration time calculations are performed, by default,
+    the calculated values are stored in the Calculator object.
     To prevent this behaviour, set the ``update_calculator`` parameter to ``False``, as shown below:
 
     .. code-block:: python

--- a/tests/functional_tests/test_calculator_usage.py
+++ b/tests/functional_tests/test_calculator_usage.py
@@ -41,7 +41,7 @@ class TestDataValidation:
         ({'t_int': {'value': 0.5, 'unit': 'min'}}, does_not_raise(), None),
         ({'t_int': {'value': 1, 'unit': 'h'}}, does_not_raise(), None),
         ({'t_int': {'value': 0, 'unit': 's'}}, pytest.raises(ValidationError),
-         value_out_of_range_exception),
+         value_too_low_exception),
         ({'t_int': {'value': float('inf'), 'unit': 's'}},
          pytest.raises(ValidationError), value_too_high_exception),
         ({'t_int': {'value': 1, 'unit': 'GHz'}},


### PR DESCRIPTION
Provides an interim solution for issue #57 

The following changes have been made:
- Lower bound on t_int relaxed; now required to be >0.
- Docs updated to reflect new lower bound on t_int.
- Updated tutorial so suggested combintaion of updated value for bandwidth and provided value for sensitivity keeps t_int within a sensible range (>1s).
- Other fix - if the user passes a sensitivity to the t_int calculation, or a t_int to the sensitivity calculation, the passed values are now used to update the calculator object (i.e., they're stored by the calculator). This is functionally equivalent to updating the calculator manually (e.g., `calculator.sensitivity=10*u.mJy`) then performing the calculation with the updated values. It also ensures that values passed to functions go through the same validation as values set directly on the calculator object.
- Docs updated to add a note about the above change.