### PR TITLE
bug fixes + default values

### DIFF
--- a/atlast_sc/calculator.py
+++ b/atlast_sc/calculator.py
@@ -293,6 +293,13 @@ class Calculator:
         return self.derived_parameters.T_sys
 
     @property
+    def T_sky(self):
+        """
+        Get the sky temperature
+        """
+        return self.derived_parameters.T_sky
+
+    @property
     def sefd(self):
         """
         Get the system equivalent flux density
@@ -488,7 +495,7 @@ class Calculator:
 
         self._derived_params = \
             DerivedParams(tau_atm=tau_atm, T_atm=T_atm, T_rx=temps.T_rx,
-                          eta_a=eta.eta_a, eta_s=eta.eta_s, T_sys=temps.T_sys,
+                          eta_a=eta.eta_a, eta_s=eta.eta_s, T_sys=temps.T_sys, T_sky=temps.T_sky,
                           sefd=sefd)
 
     def _calculate_sefd(self, T_sys, eta_a):

--- a/atlast_sc/data.py
+++ b/atlast_sc/data.py
@@ -137,7 +137,7 @@ class Data:
 
     # Sideband Ratio
     g = DataType(
-        default_value=1
+        default_value=0
     )
 
     # surface smoothness, set to 25 micron to be consistent with OHB

--- a/atlast_sc/data.py
+++ b/atlast_sc/data.py
@@ -128,10 +128,10 @@ class Data:
 
     # Elevation of the target for calculating air mass
     elevation = DataType(
-        default_value=45,
+        default_value=60,
         default_unit=str(u.deg),
-        lower_value=25,
-        upper_value=85,
+        lower_value=20,
+        upper_value=90,
         units=[str(u.deg)]
     )
 
@@ -164,7 +164,7 @@ class Data:
 
     # Forward Efficiency
     eta_eff = DataType(
-        default_value=0.8
+        default_value=0.95
     )
 
     # Illumination Efficiency
@@ -184,12 +184,12 @@ class Data:
 
     # Polarisation Efficiency
     eta_pol = DataType(
-        default_value=0.99
+        default_value=0.995
     )
 
     # Temperature of the CMB
     t_cmb = DataType(
-        default_value=2.73,
+        default_value=2.726,
         default_unit=str(u.K)
     )
 

--- a/atlast_sc/derived_groups.py
+++ b/atlast_sc/derived_groups.py
@@ -167,6 +167,13 @@ class Temperatures:
         """
         return self._T_sys
 
+    @property
+    def T_sky(self):
+        """
+        Get the sky temperature
+        """
+        return self._T_sky
+
     @staticmethod
     def _calculate_receiver_temperature(obs_freq):
         """
@@ -185,6 +192,8 @@ class Temperatures:
 
         transmittance = np.exp(-tau_atm)
         sky_temp = T_atm * (1 - transmittance) + T_cmb
+
+        self._T_sky = sky_temp
 
         return (1 + g) / (eta_eff * transmittance) * \
                (self.T_rx

--- a/atlast_sc/derived_groups.py
+++ b/atlast_sc/derived_groups.py
@@ -202,12 +202,10 @@ class Temperatures:
         """
 
         transmittance = np.exp(-tau_atm)
-        sky_temp = T_atm * (1 - transmittance) + T_cmb
-
-        self._T_sky = sky_temp
+        self._T_sky = T_atm * (1 - transmittance) + T_cmb
 
         return (1 + g) / (eta_eff * transmittance) * \
                (self.T_rx
-                + (eta_eff * sky_temp)
+                + (eta_eff * self._T_sky)
                 + ((1 - eta_eff) * T_amb)
                 )

--- a/atlast_sc/models.py
+++ b/atlast_sc/models.py
@@ -24,9 +24,7 @@ class ModelUtils:
             if not isinstance(orig_value, (floating, float)):
                 return orig_value
 
-            exponent = floor(log10(abs(orig_value)))
-
-            if exponent >= 4:
+            if orig_value!=0 and floor(log10(abs(orig_value))) >= 4:
                 new_value = f'{value:.6e}'
             else:
                 new_value = round(value, 6)
@@ -231,6 +229,8 @@ class DerivedParams(BaseModel):
     eta_s: float
     # System temperature
     T_sys: Quantity
+    # Sky temperature
+    T_sky: Quantity
     # Source equivalent flux density
     sefd: Quantity
 


### PR DESCRIPTION
During our latest WG meeting, we went through a short tutorial on how to use the sensitivity calculator. This made us realize that the current version presents some minor issues.

- the ATM model tables comprise values for `tau` and `T_sky` measured at the zenith. As such, the value should be normalized by the corresponding atmospheric absorption factor to get `T_atm` (see Eq. 7-9 in the [ALMA Memo 602](https://library.nrao.edu/public/memos/alma/main/memo602.pdf)).
- the default value for the sideband gain ratio `g` should be set equal to 0, as for SSB and 2SB receivers.
- Tony is suggesting to increase the standard `eta_eff` value from 0.8 to 0.95, as reported in the [ALMA Memo 602](https://library.nrao.edu/public/memos/alma/main/memo602.pdf), page 8.
- The defaul elevation should be higher than 45, and the allowed values shoule span the range [20,90]

This pull request should solve all the issues reported above.
Also, I am solving a potential deprecation issue by changin from scipy's `interp2d` to `RegularGridInterpolator` 