### PR TITLE
avoid log10(zero)

### DIFF
--- a/atlast_sc/models.py
+++ b/atlast_sc/models.py
@@ -24,9 +24,7 @@ class ModelUtils:
             if not isinstance(orig_value, (floating, float)):
                 return orig_value
 
-            exponent = floor(log10(abs(orig_value)))
-
-            if exponent >= 4:
+            if orig_value!=0 and floor(log10(abs(orig_value))) >= 4:
                 new_value = f'{value:.6e}'
             else:
                 new_value = round(value, 6)


### PR DESCRIPTION
This is fixing one issue with the `get_formatted_value` in `models.py`. There was no check on `orig_value` being equal to zero, potentially causing a ValueError in the `log10` call.

This is now fixed and all tests are passing (at least, locally).