### PR TITLE
Convert output to most convenient units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ dmypy.json
 */*.puml
 
 .DS_Store
+
+# fits files for example notebooks
+AtLAST_Simulator_examples/*.fits

--- a/atlast_sc/calculator.py
+++ b/atlast_sc/calculator.py
@@ -367,8 +367,14 @@ class Calculator:
             self.sefd / \
             (self.eta_s * np.sqrt(self.n_pol * self.bandwidth * t_int))
 
-        # Convert the output to mJy
-        sensitivity = sensitivity.to(u.mJy)
+        # Convert the output to the most convenient units
+        sensitivityresult = sensitivity.to(u.mJy)
+        if  sensitivityresult < 1*u.mJy:
+            sensitivity = sensitivity.to(u.uJy)
+        elif (sensitivityresult >= 1*u.mJy) & (sensitivityresult < 1000*u.mJy):
+            sensitivity = sensitivity.to(u.mJy)
+        elif sensitivityresult >= 1000*u.mJy:
+            sensitivity = sensitivity.to(u.Jy)
 
         # Try to update the sensitivity stored in the calculator
         if update_calculator:
@@ -413,8 +419,14 @@ class Calculator:
         t_int = (self.sefd / (sensitivity * self.eta_s)) ** 2 \
             / (self.n_pol * self.bandwidth)
 
-        # Convert the integration time to seconds
-        t_int = t_int.to(u.s)
+        # Convert the output to the most convenient units
+        timeresult = t_int.to(u.s)
+        if  timeresult < 60*u.s:
+            t_int = t_int.to(u.s)
+        elif (timeresult >= 60*u.s) & (timeresult < 3600*u.s):
+            t_int = t_int.to(u.min)
+        elif timeresult >= 3600*u.s:
+            t_int = t_int.to(u.h)
 
         # Try to update the integration time stored in the calculator
         if update_calculator:

--- a/atlast_sc_tests/functional_tests/test_calculator_usage.py
+++ b/atlast_sc_tests/functional_tests/test_calculator_usage.py
@@ -12,14 +12,14 @@ class TestCalculatorUsage:
         test_calculator = Calculator()
 
         # Calculate the sensitivity using default parameters
-        sens = test_calculator.calculate_sensitivity().to(u.mJy)
+        sens = test_calculator.calculate_sensitivity()
 
         # Verify that the calculator now stores the newly calculated
         # sensitivity
         assert sens == test_calculator.sensitivity
-        # Verify that the sensitivity is about 0.78 mJy
-        assert test_calculator.sensitivity.value == pytest.approx(0.78, 0.01)
-        assert test_calculator.sensitivity.unit == u.mJy
+        # Verify that the sensitivity is about 780 mJy
+        assert test_calculator.sensitivity.value == pytest.approx(780, 0.01)
+        assert test_calculator.sensitivity.unit == u.uJy
 
         # Update observing frequency
         test_calculator.obs_freq = 850 * u.GHz
@@ -58,12 +58,12 @@ class TestCalculatorUsage:
                calculator.derived_parameters
 
         # Calculate the integration time with default values
-        new_t_int = test_calculator.calculate_t_integration().to(u.s)
+        new_t_int = test_calculator.calculate_t_integration()
         # Verify that the calculator has been updated with calculated
         # integration time
         assert test_calculator.t_int == new_t_int
-        # Verify that the calculated integration time is about 100 s
-        assert test_calculator.t_int.value == pytest.approx(100, 3)
+        # Verify that the calculated integration time is about 6.76 s
+        assert test_calculator.t_int.value == pytest.approx(6.76, 0.01)
         assert test_calculator.t_int.unit == u.s
 
         # Calculate integration time using a different sensitivity

--- a/atlast_sc_tests/functional_tests/test_calculator_usage.py
+++ b/atlast_sc_tests/functional_tests/test_calculator_usage.py
@@ -12,7 +12,7 @@ class TestCalculatorUsage:
         test_calculator = Calculator()
 
         # Calculate the sensitivity using default parameters
-        sens = test_calculator.calculate_sensitivity()
+        sens = test_calculator.calculate_sensitivity().to(u.mJy)
 
         # Verify that the calculator now stores the newly calculated
         # sensitivity
@@ -58,7 +58,7 @@ class TestCalculatorUsage:
                calculator.derived_parameters
 
         # Calculate the integration time with default values
-        new_t_int = test_calculator.calculate_t_integration()
+        new_t_int = test_calculator.calculate_t_integration().to(u.s)
         # Verify that the calculator has been updated with calculated
         # integration time
         assert test_calculator.t_int == new_t_int

--- a/atlast_sc_tests/unit_tests/test_calculator.py
+++ b/atlast_sc_tests/unit_tests/test_calculator.py
@@ -227,8 +227,9 @@ class TestCalculator:
         else:
             assert calculator.sensitivity == sensitivity
 
-        # Verify that the units of the calculated sensitivity are in mJy
-        assert sens.unit == u.mJy
+        # Verify that the units of the calculated sensitivity are in units of 
+        # flux density
+        assert any(sens.unit == x for x in [u.uJy, u.mJy, u.Jy])
 
     @pytest.mark.parametrize(
         'new_sens,update_calculator',
@@ -284,8 +285,8 @@ class TestCalculator:
             assert calculator.t_int == t_int
 
         # # Verify that the units of the calculated integration time are in
-        # seconds
-        assert int_time.unit == u.s
+        # units of time
+        assert any(int_time.unit == x for x in [u.s, u.min, u.h])
 
     @pytest.mark.parametrize(
         'input_value,func_name',

--- a/fastapi_tests/test_main.py
+++ b/fastapi_tests/test_main.py
@@ -28,8 +28,8 @@ def test_calculate_sensitivity():
     assert response.status_code == 200
 
     sensitivity = response.json()
-    assert sensitivity['unit'] == 'mJy'
-    assert pytest.approx(sensitivity['value'], 0.01) == 0.78
+    assert sensitivity['unit'] == 'uJy'
+    assert pytest.approx(sensitivity['value'], 0.01) == 780.
 
 
 def test_calculate_t_int():


### PR DESCRIPTION
Improve usability by providing the output in convenient units i.e. integration time in terms of seconds, minutes or hours rather than always in seconds and sensitivity in terms of uJy, mJy or Jy rather than always in mJy. Particularly useful for web client where the output units cannot be changed.