### PR TITLE
Update documentation to avoid issues with Python 3.12

### DIFF
--- a/docs/source/user_guide/python_package_installation.rst
+++ b/docs/source/user_guide/python_package_installation.rst
@@ -22,7 +22,7 @@ environment with:
 
 .. code-block:: bash
 
-   conda env create atlast
+   conda create -n atlast python=3.11 pip
 
 
 Then activate the environment:
@@ -33,7 +33,7 @@ Then activate the environment:
 
 
 If you want to install into an environment that you're already using, note that the Sensitivity Calculator 
-package requires Python >= 3.10. You can check your version of Python by
+package currently only works with Python versions 3.10 and 3.11. You can check your version of Python by
 typing:
 
 .. code-block:: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,13 @@ authors = [
     { name="Joanna Ramasawmy", email="joanna.ramasawmy@stfc.ac.uk" },
     { name="Fiona Kirton", email="fiona.kirton@gmail.com"}
 ]
+maintainers = [
+    { name="Mark Booth", email="mark.booth@stfc.ac.uk" },
+    { name="Pamela Klaassen, email="pamela.klaassen@stfc.ac.uk"}
+]
 description = "AtLast sensitivity calculator"
 #license = "MIT"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<=3.11"
 dependencies = [
     "astropy == 5.1.*",
     "numpy == 1.23.*",


### PR DESCRIPTION
I've updated the installation instructions to avoid the issues with Python 3.12 and make sure pip is installed from the start.

I've also included myself and Pamela as maintainers in the pyproject file.