### PR TITLE
Linttestupdate

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -14,12 +14,13 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.10'
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
+    #- name: Add conda to system path
+    #  run: |
+    #    # $CONDA is an environment variable pointing to the root of the miniconda directory
+    #    echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
+        conda install -y python=3.10
         conda env update --file environment.yml --name base
     - name: Lint with flake8
       run: |

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         conda install -y python=3.10
+        echo $CONDA/bin >> $GITHUB_PATH
         conda env update --file environment.yml --name base
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
Test file was using the Python 3.12 version of conda while using Python 3.10 versions for everything else. This stopped the tests from running, impeding any updates to the package. Needed to install specific version of conda to get the test file working again.