### PR TITLE
Asc 145/python version

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,4 +1,4 @@
-1.1.2 (2025-04-15)
+1.1.2 (2026-04-15)
 ++++++++++++++++++
 - Set a maximum Python version as the calculator is not currently compatible with Python >=3.13.
 - Change the installation instructions to specify a specific Python version.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,8 @@
+1.1.2 (2025-04-15)
+++++++++++++++++++
+- Set a maximum Python version as the calculator is not currently compatible with Python >=3.13.
+- Change the installation instructions to specify a specific Python version.
+
 1.1.1 (2025-01-22)
 ++++++++++++++++++
 - Updates to readthedocs files to enable readthedocs to display API and UML pages and to automatically create a pdf.

--- a/docs/source/user_guide/python_package_installation.rst
+++ b/docs/source/user_guide/python_package_installation.rst
@@ -23,29 +23,16 @@ environment with:
 .. code-block:: bash
 
 
-   conda create -n atlast python pip
+   conda create -n atlast python=3.12 pip
 
+
+Note that the calculator is tested to work with Python versions 3.10 to 3.12. We cannot ensure compatibility with future versions and so it is necessary to specify the version here.
 
 Then activate the environment:
 
 .. code-block:: bash
 
    conda activate atlast
-
-
-If you want to install into an environment that you're already using, note that the Sensitivity Calculator 
-package requires Python >= 3.10. You can check your version of Python by
-typing:
-
-.. code-block:: bash
-
-    python -V
-
-If this returns ``2.x.x``, then try:
-
-.. code-block:: bash
-
-    python3 -V
 
 
 Installing the sensitivity calculator Python package

--- a/docs/source/user_guide/python_package_installation.rst
+++ b/docs/source/user_guide/python_package_installation.rst
@@ -26,7 +26,7 @@ environment with:
    conda create -n atlast python=3.12 pip
 
 
-Note that the calculator is tested to work with Python versions 3.10 to 3.12. We cannot ensure compatibility with future versions and so it is necessary to specify the version here.
+Note that the calculator is tested to work with Python versions 3.10 to 3.12. We cannot ensure compatibility with other versions and so it is necessary to specify the version here.
 
 After the environment is created, activate it with:
 

--- a/docs/source/user_guide/python_package_installation.rst
+++ b/docs/source/user_guide/python_package_installation.rst
@@ -28,12 +28,19 @@ environment with:
 
 Note that the calculator is tested to work with Python versions 3.10 to 3.12. We cannot ensure compatibility with future versions and so it is necessary to specify the version here.
 
-Then activate the environment:
+After the environment is created, activate it with:
 
 .. code-block:: bash
 
    conda activate atlast
 
+
+If you want to install into an environment that you are already using, you can check your version of Python by
+typing:
+
+.. code-block:: bash
+
+    python -V
 
 Installing the sensitivity calculator Python package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 ]
 description = "AtLast sensitivity calculator"
 #license = "MIT"
-requires-python = "==3.12"
+requires-python = "(>=3.10.*, <=3.12.*)"
 dependencies = [
     "astropy == 5.3.*",
     "numpy == 1.26.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 ]
 description = "AtLast sensitivity calculator"
 #license = "MIT"
-requires-python = ">=3.10"
+requires-python = "==3.12"
 dependencies = [
     "astropy == 5.3.*",
     "numpy == 1.26.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 ]
 description = "AtLast sensitivity calculator"
 #license = "MIT"
-requires-python = "(>=3.10.*, <=3.12.*)"
+requires-python = ">=3.10, <3.13"
 dependencies = [
     "astropy == 5.3.*",
     "numpy == 1.26.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["atlast_sc*"]
 
 [project]
 name = "atlast_sc"
-version = "1.1.1"
+version = "1.1.2"
 authors = [
     { name="Joanna Ramasawmy", email="joanna.ramasawmy@stfc.ac.uk" },
     { name="Fiona Kirton", email="fiona.kirton@gmail.com"}


### PR DESCRIPTION
The calculator is not compatible with Python versions 3.13 and 3.14 due to a change in setuptools that conflicts with the version of astropy that we have in our requirements. Therefore this pull request

- changes the instructions to use a specific python version
- changes pyproject.toml to include an upper bound on the python version so that an error is given if a user tries to install into an environment with a more recent version

I've also taken this opportunity to remove the information on python 2 as everyone should have moved on from that by now, as discussed in our meeting yesterday.