### PR TITLE
Add/update dependencies for creating docs locally. Remove epub option.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -39,5 +39,5 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
    - pdf
-   - epub
+#   - epub # A lot of the formatting does not work well in this format, especially equations
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,20 +1,24 @@
+2.0.0-alpha.2 (2026-04-27)
+++++++++++++++++++++++++++
+- Added / updated dependencies to ensure documentation could be generated locally.
+
 2.0.0-alpha.1 (2026-03-20)
 ++++++++++++++++++++++++++
-- Refactored code to improve flexibility
-- Changed the names and workings of calculation input parameter classes to make more sense with the addition of instrument modules
-- Added functionality for instrument modules to be introduced for calculating the system temperature
-- Added specific instrument modules to represent CHAI, FINER, MUSCAT, SEPIA, TIFUUN
-- Added automatic instrument selection based on observing frequency and bandwidth input by user
-- Added instrument selection option on the CLI 
-- Added functionality to see if requested instrument can be chosen
-- Added functionality to show a list of instruments with their observing frequency and bandwidth ranges
-- Made instrument name specification case insensitive
-- Modified unit tests according to the new structure
-- More explanatory exception messages
-- Changed am model output to produce Rayleigh-Jeans brightness temperature and to avoid including CMB (to avoid counting it twice)
-- Changed system temperature and sky temperature equations to ensure all temperatures are noise temperatures
-- Added notebook walkthroughs for each of the instruments
-- Documentation updates to take account of these changes
+- Refactored code to improve flexibility.
+- Changed the names and workings of calculation input parameter classes to make more sense with the addition of instrument modules.
+- Added functionality for instrument modules to be introduced for calculating the system temperature.
+- Added specific instrument modules to represent CHAI, FINER, MUSCAT, SEPIA, TIFUUN.
+- Added automatic instrument selection based on observing frequency and bandwidth input by user.
+- Added instrument selection option on the CLI.
+- Added functionality to see if requested instrument can be chosen.
+- Added functionality to show a list of instruments with their observing frequency and bandwidth ranges.
+- Made instrument name specification case insensitive.
+- Modified unit tests according to the new structure.
+- More explanatory exception messages.
+- Changed am model output to produce Rayleigh-Jeans brightness temperature and to avoid including CMB (to avoid counting it twice).
+- Changed system temperature and sky temperature equations to ensure all temperatures are noise temperatures.
+- Added notebook walkthroughs for each of the instruments.
+- Documentation updates to take account of these changes.
 
 1.1.2 (2026-04-15)
 ++++++++++++++++++

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,9 @@ dependencies:
   - PyYAML=6.0
   - scipy=1.11
   - setuptools=65.5
-  - sphinx_rtd_theme=1.1
+  - sphinx-rtd-theme=3.1
+  - myst-parser==2.0.0
+  - plantuml=1.2026
   - nbsphinx==0.9
   - python-dotenv=0.21
   - pydantic=2.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["atlast_sc*"]
 
 [project]
 name = "atlast_sc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 authors = [
     { name="Joanna Ramasawmy", email="joanna.ramasawmy@stfc.ac.uk" },
     { name="Fiona Kirton", email="fiona.kirton@gmail.com"}


### PR DESCRIPTION
PR 113 fixed the issues with the UML diagrams not showing up in readthedocs. However, the update to the requirements also needed to be propagated to the environment.yml so that the documentation can be generated locally.

In addition, I've removed the option to create an epub version of the documentation in readthedocs as the formatting does work well, particularly the equations - and I doubt anyone is ever going to want the documentation in this format.